### PR TITLE
add admin levels to geocoding results

### DIFF
--- a/Addok.php
+++ b/Addok.php
@@ -128,6 +128,7 @@ final class Addok extends AbstractHttpProvider implements Provider
                 'streetName'   => $streetName,
                 'locality'     => $locality,
                 'postalCode'   => $postalCode,
+                'adminLevels'  => $this->getAdminLevels($feature->properties),
             ]);
         }
 
@@ -165,6 +166,7 @@ final class Addok extends AbstractHttpProvider implements Provider
                 'streetName'   => $streetName,
                 'locality'     => $municipality,
                 'postalCode'   => $postalCode,
+                'adminLevels'  => $this->getAdminLevels($feature->properties),
             ]);
         }
 
@@ -194,5 +196,37 @@ final class Addok extends AbstractHttpProvider implements Provider
         }
 
         return $json;
+    }
+
+    /**
+     * @param \stdClass $properties
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function getAdminLevels(\stdClass $properties): array
+    {
+        $adminLevels = [];
+
+        $context = !empty($properties->context) ? $properties->context : null;
+        if ($context) {
+            $contextParts = explode(',', $context);
+            $departmentCode   = trim($contextParts[0] ?? '');
+            $departementLabel = trim($contextParts[1] ?? '');
+            $regionLabel      = trim($contextParts[2] ?? '');
+
+            $adminLevels[] = ['level' => 2, 'name' => $regionLabel];
+            $adminLevels[] = ['level' => 3, 'name' => $departementLabel, 'code' => $departmentCode];
+        }
+
+        $cityCode = !empty($properties->citycode) ? $properties->citycode : null;
+        $municipality = !empty($properties->city) ? $properties->city : null;
+        if ($cityCode && $municipality) {
+            $adminLevels[] = ['level' => 4, 'name' => $municipality, 'code' => $cityCode];
+        }
+
+        $district = !empty($properties->district) ? $properties->district : null;
+        $adminLevels[] = ['level' => 5, 'name' => $district];
+
+        return $adminLevels;
     }
 }

--- a/Addok.php
+++ b/Addok.php
@@ -210,9 +210,9 @@ final class Addok extends AbstractHttpProvider implements Provider
         $context = !empty($properties->context) ? $properties->context : null;
         if ($context) {
             $contextParts = explode(',', $context);
-            $departmentCode   = trim($contextParts[0] ?? '');
+            $departmentCode = trim($contextParts[0] ?? '');
             $departementLabel = trim($contextParts[1] ?? '');
-            $regionLabel      = trim($contextParts[2] ?? '');
+            $regionLabel = trim($contextParts[2] ?? '');
 
             $adminLevels[] = ['level' => 2, 'name' => $regionLabel];
             $adminLevels[] = ['level' => 3, 'name' => $departementLabel, 'code' => $departmentCode];

--- a/Tests/AddokTest.php
+++ b/Tests/AddokTest.php
@@ -65,6 +65,12 @@ class AddokTest extends BaseTestCase
         $this->assertEquals('Quai de la Tourelle', $result->getStreetName());
         $this->assertEquals('95000', $result->getPostalCode());
         $this->assertEquals('Cergy', $result->getLocality());
+        $this->assertCount(3, $result->getAdminLevels());
+        $this->assertEquals('Île-de-France', $result->getAdminLevels()->get(2)->getName());
+        $this->assertEquals('Val-d\'Oise', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('95', $result->getAdminLevels()->get(3)->getCode());
+        $this->assertEquals('Cergy', $result->getAdminLevels()->get(4)->getName());
+        $this->assertEquals('95127', $result->getAdminLevels()->get(4)->getCode());
     }
 
     public function testGeocodeQuery()
@@ -84,6 +90,12 @@ class AddokTest extends BaseTestCase
         $this->assertEquals('Quai de la Tourelle', $result->getStreetName());
         $this->assertEquals('95000', $result->getPostalCode());
         $this->assertEquals('Cergy', $result->getLocality());
+        $this->assertCount(3, $result->getAdminLevels());
+        $this->assertEquals('Île-de-France', $result->getAdminLevels()->get(2)->getName());
+        $this->assertEquals('Val-d\'Oise', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('95', $result->getAdminLevels()->get(3)->getCode());
+        $this->assertEquals('Cergy', $result->getAdminLevels()->get(4)->getName());
+        $this->assertEquals('95127', $result->getAdminLevels()->get(4)->getCode());
     }
 
     public function testGeocodeOnlyCityQuery()
@@ -102,6 +114,12 @@ class AddokTest extends BaseTestCase
         $this->assertNull($result->getStreetName());
         $this->assertEquals('38000', $result->getPostalCode());
         $this->assertEquals('Grenoble', $result->getLocality());
+        $this->assertCount(3, $result->getAdminLevels());
+        $this->assertEquals('Auvergne-Rhône-Alpes', $result->getAdminLevels()->get(2)->getName());
+        $this->assertEquals('Isère', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('38', $result->getAdminLevels()->get(3)->getCode());
+        $this->assertEquals('Grenoble', $result->getAdminLevels()->get(4)->getName());
+        $this->assertEquals('38185', $result->getAdminLevels()->get(4)->getCode());
     }
 
     public function testGeocodeHouseNumberTypeQuery()
@@ -120,6 +138,13 @@ class AddokTest extends BaseTestCase
         $this->assertEquals('Avenue Kléber', $result->getStreetName());
         $this->assertEquals('75016', $result->getPostalCode());
         $this->assertEquals('Paris', $result->getLocality());
+        $this->assertCount(4, $result->getAdminLevels());
+        $this->assertEquals('Île-de-France', $result->getAdminLevels()->get(2)->getName());
+        $this->assertEquals('Paris', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('75', $result->getAdminLevels()->get(3)->getCode());
+        $this->assertEquals('Paris', $result->getAdminLevels()->get(4)->getName());
+        $this->assertEquals('75116', $result->getAdminLevels()->get(4)->getCode());
+        $this->assertEquals('Paris 16e Arrondissement', $result->getAdminLevels()->get(5)->getName());
     }
 
     public function testGeocodeStreetTypeQuery()
@@ -138,6 +163,13 @@ class AddokTest extends BaseTestCase
         $this->assertEquals('Avenue Kléber', $result->getStreetName());
         $this->assertEquals('75016', $result->getPostalCode());
         $this->assertEquals('Paris', $result->getLocality());
+        $this->assertCount(4, $result->getAdminLevels());
+        $this->assertEquals('Île-de-France', $result->getAdminLevels()->get(2)->getName());
+        $this->assertEquals('Paris', $result->getAdminLevels()->get(3)->getName());
+        $this->assertEquals('75', $result->getAdminLevels()->get(3)->getCode());
+        $this->assertEquals('Paris', $result->getAdminLevels()->get(4)->getName());
+        $this->assertEquals('75116', $result->getAdminLevels()->get(4)->getCode());
+        $this->assertEquals('Paris 16e Arrondissement', $result->getAdminLevels()->get(5)->getName());
     }
 
     public function testGeocodeLocalityQuery()


### PR DESCRIPTION
Extends geocoding functionality by adding support for administrative levels in results. : 

Level 2: Region (e.g., "Pays de la Loire")
Level 3: Department (Name and Code, e.g., "Vendé" / "85")
Level 4: Municipality (Name and INSEE Code as the Level code, e.g., "28236")
Level 5 : District / Arrondissement (Name of the district, e.g., "Paris 16e Arrondissement")

See Issue #14 